### PR TITLE
Add four-tier verification pipeline (analyze, codegen, build, tests)

### DIFF
--- a/.claude/hooks/verify-before-stop.sh
+++ b/.claude/hooks/verify-before-stop.sh
@@ -9,16 +9,65 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# build_runner first, since analyze is meaningless against stale/missing .g.dart files
+# Two verification speeds: "full" (default) runs all four tiers; "light" stops after
+# analyze, for quick iteration/live-debugging where a multi-minute build every turn
+# is too much. Claude opts into light mode for a single upcoming turn by running
+# `mkdir -p .claude && echo light > .claude/.verify-level` before finishing — see
+# CLAUDE.md. The marker is one-shot: read once here, then removed, so the next turn
+# defaults back to full unless explicitly set again.
+LEVEL_FILE=".claude/.verify-level"
+LEVEL="full"
+if [ -f "$LEVEL_FILE" ]; then
+  LEVEL="$(tr -d '[:space:]' < "$LEVEL_FILE")"
+  rm -f "$LEVEL_FILE"
+fi
+if [ "$LEVEL" != "light" ]; then
+  LEVEL="full"
+fi
+
+# Tier 2 (codegen) first, since analyze/build/test are meaningless against
+# stale/missing .g.dart/.freezed.dart files.
 if ! dart run build_runner build --delete-conflicting-outputs > /tmp/br.log 2>&1; then
   echo "build_runner failed. Fix these errors before finishing:" >&2
   tail -n 40 /tmp/br.log >&2
   exit 2
 fi
 
+# Tier 1: static analysis.
 if ! flutter analyze > /tmp/analyze.log 2>&1; then
   echo "flutter analyze found issues. Fix them before finishing:" >&2
   cat /tmp/analyze.log >&2
+  exit 2
+fi
+
+if [ "$LEVEL" = "light" ]; then
+  exit 0
+fi
+
+# Tier 4a: offline unit/widget tests. Excludes tier 4b (tagged 'live') by default —
+# dart_test.yaml skips that tag unless explicitly requested with --tags=live.
+if ! flutter test > /tmp/test.log 2>&1; then
+  echo "flutter test found failures. Fix them before finishing:" >&2
+  tail -n 80 /tmp/test.log >&2
+  exit 2
+fi
+
+# Tier 4b: live API coverage tests. --run-skipped overrides dart_test.yaml's
+# always-skip for the 'live' tag; --tags=live still means "only these". Local-only
+# by construction (this hook only ever runs on this machine, never in CI) and safe to
+# run without credentials configured — see test/live/README.md — it then just runs a
+# trivial placeholder test instead of failing.
+if ! flutter test --tags=live --run-skipped > /tmp/test-live.log 2>&1; then
+  echo "flutter test --tags=live found failures. Fix them before finishing:" >&2
+  tail -n 80 /tmp/test-live.log >&2
+  exit 2
+fi
+
+# Tier 3: build. Debug + single ABI — release would fail without a local
+# signing key.properties, and this only needs to prove the app compiles.
+if ! flutter build apk --debug --target-platform android-arm64 > /tmp/build.log 2>&1; then
+  echo "flutter build apk --debug failed. Fix these errors before finishing:" >&2
+  tail -n 60 /tmp/build.log >&2
   exit 2
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/verify-before-stop.sh",
-            "timeout": 300
+            "timeout": 600
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# No secrets are used anywhere in this workflow. Tier 4b (live API tests, tagged
+# `live`) is intentionally never run here — it only runs locally, see
+# test/live/README.md.
+env:
+  FLUTTER_VERSION: "3.47.0"
+
+jobs:
+  analyze:
+    name: Static analysis (tier 1)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: flutter analyze
+
+  codegen-check:
+    name: Codegen leaves no diff (tier 2)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Fail if build_runner produced a tracked-file diff
+        run: |
+          if [ -n "$(git status --porcelain -- '*.g.dart' '*.freezed.dart')" ]; then
+            echo "build_runner changed a tracked generated file — these should be gitignored:"
+            git status --porcelain -- '*.g.dart' '*.freezed.dart'
+            exit 1
+          fi
+
+  test:
+    name: Offline tests (tier 4a)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: flutter test
+
+  build:
+    name: Build debug APK (tier 3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      # Debug, not release: release signing needs a local key.properties that
+      # deliberately doesn't exist in CI (see android/app/build.gradle.kts).
+      - run: flutter build apk --debug --target-platform android-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   analyze:
-    name: Static analysis (tier 1)
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - run: flutter analyze
 
   codegen-check:
-    name: Codegen leaves no diff (tier 2)
+    name: code-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           fi
 
   test:
-    name: Offline tests (tier 4a)
+    name: tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - run: flutter test
 
   build:
-    name: Build debug APK (tier 3)
+    name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,11 @@ credentials.txt
 credentials.csv
 
 devtools_options.yaml
+
+# Local-only live-API test credentials (tier 4b) — never commit real school
+# credentials. See test/live/README.md.
+test/live/credentials.local.json
+
+# One-shot marker for the Stop hook's verification level (full vs. light) for the
+# next turn only — ephemeral local state, not project config. See CLAUDE.md.
+.claude/.verify-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,40 @@ flutter run
 
 # Build a release APK
 flutter build apk
+
+# Offline tests (fixtures, no network/credentials)
+flutter test
+
+# Live API coverage tests — real credentials, local-only, never run this in CI;
+# see test/live/README.md. Both flags matter: --run-skipped overrides
+# dart_test.yaml's default skip for the 'live' tag.
+flutter test --tags=live --run-skipped
 ```
 
-There is no test suite in this repository at present (no `test/` directory).
+## Verification
+
+This repo has a four-tier verification pipeline (static analysis, codegen, build, tests — see
+`README.md`'s "Verification" section for the full breakdown) enforced two ways: a GitHub Actions
+workflow on every PR (tiers 1–3 + offline tests only — never the live-API tier), and a Claude Code
+`Stop` hook (`.claude/hooks/verify-before-stop.sh`) that runs before you can finish a turn.
+
+The hook runs at one of two speeds:
+
+- **full** (default): codegen → analyze → offline tests → live API tests → debug APK build. The
+  live-API step is safe by default even without credentials configured — see
+  `test/live/README.md` — it just runs a trivial placeholder test in that case.
+- **light**: codegen → analyze only. Use this for small, exploratory, or live-debugging turns where
+  a multi-minute build isn't worth paying for — a single-file fix, iterating on one function, a
+  quick config tweak. For anything that changes behavior more substantially — new
+  models/providers/screens, anything touching the request/parsing layer, multi-file changes — leave
+  it on the default `full` speed so the build and test suite actually run.
+
+To opt into light mode for the *next* Stop only, run this before finishing:
+```shell
+mkdir -p .claude && echo light > .claude/.verify-level
+```
+This is one-shot: the hook deletes the marker after reading it, so the following turn defaults back
+to `full` unless you set it again. When in doubt, do nothing — `full` is the safe default.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ me.
 
 Pull requests and issues are always welcome.
 
+## Verification
+
+Before opening a PR, this project expects:
+
+1. **Static analysis** — `flutter analyze` must pass cleanly.
+2. **Code generation** — `dart run build_runner build --delete-conflicting-outputs` must succeed.
+3. **Build** — `flutter build apk --debug --target-platform android-arm64` must succeed. (Release
+   builds need a local `key.properties` this repo doesn't ship with, so verification always targets
+   debug.)
+4. **Tests**, in two tiers:
+   - `flutter test` — offline unit tests against fixtures derived from `docs/api/captures/`, no
+     network or credentials needed.
+   - `flutter test --tags=live --run-skipped` — exercises the real Untis API with real school
+     credentials to check everything still parses. **Never run in CI.** See
+     [`test/live/README.md`](test/live/README.md) for how to provide credentials.
+
+Tiers 1–3 and the offline test tier run in CI on every PR
+([`.github/workflows/ci.yml`](.github/workflows/ci.yml)). Locally, the Claude Code `Stop` hook
+([`.claude/hooks/verify-before-stop.sh`](.claude/hooks/verify-before-stop.sh)) runs all of the
+above, including the live-API tier, at its default `full` verification level — see `CLAUDE.md`.
+
 ### Code generation
 
 Generate the nessessary code:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
 
 val keystoreProperties = Properties()
 val keystorePropertiesFile = rootProject.file("key.properties")
-if (keystorePropertiesFile.exists()) {
+val hasKeystoreProperties = keystorePropertiesFile.exists()
+if (hasKeystoreProperties) {
     keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
@@ -45,11 +46,17 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+        // Gradle configures this whole `android {}` block for every task, including
+        // `assembleDebug` — not just when a release build is actually requested — so
+        // this must not crash when key.properties is absent (e.g. CI, a fresh
+        // checkout without the maintainer's local signing key).
+        if (hasKeystoreProperties) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = keystoreProperties["storeFile"]?.let { file(it) }
+                storePassword = keystoreProperties["storePassword"] as String
+            }
         }
     }
 
@@ -57,7 +64,9 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("release")
+            if (hasKeystoreProperties) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 }

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,3 @@
+tags:
+  live:
+    skip: "Live integration tests require local credentials and hit the real Untis API — run explicitly with: flutter test --tags=live (see test/live/README.md)"

--- a/lib/core/untis/requests/request_exams.dart
+++ b/lib/core/untis/requests/request_exams.dart
@@ -53,7 +53,7 @@ class RequestExams extends _$RequestExams {
       case RPCResponseResult():
         {
           // Get exam set
-          var examSet = (response.result.result['exams'] as List<dynamic>).map((
+          var examSet = (response.result['exams'] as List<dynamic>).map((
               e) => Exam.fromJson(e)).toSet();
           //Create empty map
           var examMap = <Date, List<Exam>>{

--- a/lib/core/untis/requests/request_messages.dart
+++ b/lib/core/untis/requests/request_messages.dart
@@ -40,8 +40,7 @@ class RequestMessages extends _$RequestMessages {
       {'school': session.school.loginName},
     );
 
-    AuthToken? authToken =
-        session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
+    AuthToken authToken = await ref.read(authTokenProvider(session).future);
 
     http.Response response;
     try {

--- a/lib/core/untis/requests/request_messages.dart
+++ b/lib/core/untis/requests/request_messages.dart
@@ -14,6 +14,10 @@ class RequestMessages extends _$RequestMessages {
   Future<Messages> build(UntisSession activeSession) async {
     assert(activeSession is ActiveUntisSession, 'Session must be active');
     ActiveUntisSession session = activeSession as ActiveUntisSession;
+    assert(
+      session.loginMode != LoginMode.anonymous,
+      'Messages are not available for anonymous sessions (confirmed 403 Forbidden server-side).',
+    );
 
     listenSelf((previous, data) {
       if (previous == data) {
@@ -36,14 +40,15 @@ class RequestMessages extends _$RequestMessages {
       {'school': session.school.loginName},
     );
 
-    AuthToken authToken = await ref.read(authTokenProvider(session).future);
+    AuthToken? authToken =
+        session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
 
     http.Response response;
     try {
       response = await http.get(
         uri,
         headers: {
-          'Authorization': 'Bearer ${authToken.jwt}',
+          ...session.restAuthHeaders(authToken),
           'Content-Type': 'application/json; charset=UTF-8',
           'Accept-Encoding': 'gzip',
           'Cache-Control': 'public, no-cache',

--- a/lib/core/untis/requests/request_mobile_data.dart
+++ b/lib/core/untis/requests/request_mobile_data.dart
@@ -25,13 +25,14 @@ Future<MobileData> requestMobileData(Ref ref, UntisSession activeSession) async 
     {'school': session.school.loginName},
   );
 
-  AuthToken authToken = await ref.read(authTokenProvider(session).future);
+  AuthToken? authToken =
+      session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
 
   http.Response response;
   try {
     response = await http.get(
       uri,
-      headers: {'Authorization': 'Bearer ${authToken.jwt}'},
+      headers: session.restAuthHeaders(authToken),
     );
   } catch (e, s) {
     getLogger().e('Error while requesting mobile data', error: e, stackTrace: s);

--- a/lib/core/untis/requests/request_specified_message.dart
+++ b/lib/core/untis/requests/request_specified_message.dart
@@ -43,8 +43,7 @@ class RequestSpecifiedMessage extends _$RequestSpecifiedMessage {
       {'school': session.school.loginName},
     );
 
-    AuthToken? authToken =
-        session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
+    AuthToken authToken = await ref.read(authTokenProvider(session).future);
 
     http.Response response;
     try {

--- a/lib/core/untis/requests/request_specified_message.dart
+++ b/lib/core/untis/requests/request_specified_message.dart
@@ -14,6 +14,10 @@ class RequestSpecifiedMessage extends _$RequestSpecifiedMessage {
   Future<SpecifiedMessage> build(UntisSession activeSession, int messageId) async {
     assert(activeSession is ActiveUntisSession, 'Session must be active');
     ActiveUntisSession session = activeSession as ActiveUntisSession;
+    assert(
+      session.loginMode != LoginMode.anonymous,
+      'Messages are not available for anonymous sessions (confirmed 403 Forbidden server-side).',
+    );
 
     listenSelf((previous, data) {
       if (previous == data) {
@@ -39,14 +43,15 @@ class RequestSpecifiedMessage extends _$RequestSpecifiedMessage {
       {'school': session.school.loginName},
     );
 
-    AuthToken authToken = await ref.read(authTokenProvider(session).future);
+    AuthToken? authToken =
+        session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
 
     http.Response response;
     try {
       response = await http.get(
         uri,
         headers: {
-          'Authorization': 'Bearer ${authToken.jwt}',
+          ...session.restAuthHeaders(authToken),
           'Content-Type': 'application/json; charset=UTF-8',
           'Accept-Encoding': 'gzip',
           'Cache-Control': 'public, no-cache',

--- a/lib/core/untis/requests/request_timetable_entries.dart
+++ b/lib/core/untis/requests/request_timetable_entries.dart
@@ -68,13 +68,14 @@ class RequestTimetableEntries extends _$RequestTimetableEntries {
       'school': session.school.loginName,
     });
 
-    AuthToken authToken = await ref.read(authTokenProvider(session).future);
+    AuthToken? authToken =
+        session.loginMode == LoginMode.anonymous ? null : await ref.read(authTokenProvider(session).future);
 
     http.Response response;
     try {
       response = await http.get(
         uri,
-        headers: {'Authorization': 'Bearer ${authToken.jwt}'},
+        headers: session.restAuthHeaders(authToken),
       );
     } catch (e, s) {
       getLogger().e('Error while requesting timetable entries', error: e, stackTrace: s);

--- a/lib/core/untis/untis_session.dart
+++ b/lib/core/untis/untis_session.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -63,6 +65,24 @@ extension ActiveUntisSessionAuthParams on ActiveUntisSession {
         LoginMode.anonymous => const AuthParams.anonymous(),
         LoginMode.password || LoginMode.ssoKey =>
           AuthParams.credentials(user: username!, appSharedSecret: appSharedSecret!),
+      };
+}
+
+extension ActiveUntisSessionRestAuthHeaders on ActiveUntisSession {
+  /// Auth header(s) for the REST (`/WebUntis/api/**`) endpoints — as opposed to
+  /// JSON-RPC, which uses [authParams]. Anonymous sessions send
+  /// `anonymous-school-base64` (base64 of the school's `loginName`) instead of a
+  /// bearer token: confirmed live (against `bs-gfv`) that REST endpoints reject the
+  /// anonymous account's own JWT with `401 Unauthorized`, even though `getAuthToken`
+  /// itself succeeds. See `docs/api/spec/NOTES.md` §2b. [authToken] is unused for
+  /// anonymous sessions — callers don't need to fetch one at all in that case.
+  Map<String, String> restAuthHeaders(AuthToken? authToken) => switch (loginMode) {
+        LoginMode.anonymous => {
+            'anonymous-school-base64': base64Encode(utf8.encode(school.loginName)),
+          },
+        LoginMode.password || LoginMode.ssoKey => {
+            'Authorization': 'Bearer ${authToken!.jwt}',
+          },
       };
 }
 

--- a/lib/ui/shared/my_drawer.dart
+++ b/lib/ui/shared/my_drawer.dart
@@ -48,18 +48,21 @@ class MyDrawer extends ConsumerWidget {
               );
             },
           ),
-          ListTile(
-            title: const Text('Nachrichten'),
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const MessagesScreen(),
-                ),
-              );
-            },
-          ),
+          // Messages are not available for anonymous sessions — confirmed 403
+          // Forbidden server-side, not something a retry/fix on our end can solve.
+          if (session.loginMode != LoginMode.anonymous)
+            ListTile(
+              title: const Text('Nachrichten'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const MessagesScreen(),
+                  ),
+                );
+              },
+            ),
           Expanded(child: Container()),
           ListTile(
             title: const Text('Einstellungen'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -431,7 +431,7 @@ packages:
     source: hosted
     version: "4.2.2"
   flutter_test:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -672,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.8.1"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   nm:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   open_filex: ^4.7.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   flutter_launcher_icons: ^0.14.4
   build_runner: ^2.16.0
@@ -41,6 +43,7 @@ dev_dependencies:
   json_serializable: ^6.14.1
   riverpod_generator: ^4.0.8
   riverpod_lint: ^3.1.8
+  mocktail: ^1.0.4
 
 flutter_launcher_icons:
   android: true

--- a/test/fixtures/exam_item_synthetic.json
+++ b/test/fixtures/exam_item_synthetic.json
@@ -1,0 +1,19 @@
+{
+  "id": 501,
+  "examType": "KLA",
+  "startDateTime": "2026-09-15T08:00:00",
+  "endDateTime": "2026-09-15T09:35:00",
+  "subjectId": 1530,
+  "klasseIds": [1685],
+  "roomIds": [1349],
+  "teacherIds": [823],
+  "invigilators": [
+    {
+      "id": 823,
+      "startTime": "T07:55",
+      "endTime": "T09:35"
+    }
+  ],
+  "name": "Klausur Mathematik",
+  "text": "Taschenrechner erlaubt"
+}

--- a/test/fixtures/exams_rpc_response_empty.json
+++ b/test/fixtures/exams_rpc_response_empty.json
@@ -1,0 +1,9 @@
+{
+  "jsonrpc": "2.0",
+  "id": "0",
+  "result": {
+    "type": "CLASS",
+    "id": 1664,
+    "exams": []
+  }
+}

--- a/test/fixtures/login_meta.json
+++ b/test/fixtures/login_meta.json
@@ -1,0 +1,4 @@
+{
+  "anonymousLoginEnabled": false,
+  "ssoLoginEnabled": true
+}

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -1,0 +1,39 @@
+{
+  "incomingMessages": [
+    {
+      "id": 4890,
+      "subject": "Gottesdienst-Erinnerung: Jg. 10 Gym/RS, EF, Q1 am 10.06.2026, 2. Std",
+      "contentPreview": "Liebe Schüler:innen, am Mittwoch, den 10.06.2026 findet in der 2. Stunde unser letzter Gottesdienst in diesem Schuljahr statt.",
+      "sender": {
+        "className": null,
+        "displayName": "Admin_1",
+        "imageUrl": null,
+        "userId": 67
+      },
+      "sentDateTime": "2026-06-08T12:25:00",
+      "allowMessageDeletion": false,
+      "hasAttachments": false,
+      "isMessageRead": true,
+      "isReply": false,
+      "isReplyAllowed": false
+    },
+    {
+      "id": 4857,
+      "subject": "Schulmusical - Termine nächste Woche!",
+      "contentPreview": "Liebe Schulgemeinde, hier die Ankündigung des Schulmusicals.",
+      "sender": {
+        "className": null,
+        "displayName": "Admin_2",
+        "imageUrl": null,
+        "userId": 145
+      },
+      "sentDateTime": "2026-06-05T15:52:00",
+      "allowMessageDeletion": false,
+      "hasAttachments": true,
+      "isMessageRead": true,
+      "isReply": false,
+      "isReplyAllowed": false
+    }
+  ],
+  "readConfirmationMessages": []
+}

--- a/test/fixtures/school.json
+++ b/test/fixtures/school.json
@@ -1,0 +1,12 @@
+{
+  "server": "cjd-koewi.webuntis.com",
+  "useMobileServiceUrlAndroid": false,
+  "address": "53639, Königswinter, Cleethorpeser Platz 12",
+  "displayName": "CJD Königswinter Christophorusschule",
+  "loginName": "cjd-koewi",
+  "schoolId": 5237400,
+  "useMobileServiceUrlIos": false,
+  "serverUrl": "https://cjd-koewi.webuntis.com/WebUntis/?school=cjd-koewi",
+  "tenantId": "5237400",
+  "mobileServiceUrl": null
+}

--- a/test/fixtures/school_search_rpc_response.json
+++ b/test/fixtures/school_search_rpc_response.json
@@ -1,0 +1,21 @@
+{
+  "result": {
+    "size": 0,
+    "schools": [
+      {
+        "server": "cjd-koewi.webuntis.com",
+        "useMobileServiceUrlAndroid": false,
+        "address": "53639, Königswinter, Cleethorpeser Platz 12",
+        "displayName": "CJD Königswinter Christophorusschule",
+        "loginName": "cjd-koewi",
+        "schoolId": 5237400,
+        "useMobileServiceUrlIos": false,
+        "serverUrl": "https://cjd-koewi.webuntis.com/WebUntis/?school=cjd-koewi",
+        "tenantId": "5237400",
+        "mobileServiceUrl": null
+      }
+    ]
+  },
+  "id": "untis-mobile-android-6.7.0",
+  "jsonrpc": "2.0"
+}

--- a/test/fixtures/specified_message_external_attachment.json
+++ b/test/fixtures/specified_message_external_attachment.json
@@ -1,0 +1,33 @@
+{
+  "id": 11743,
+  "subject": "Wintertürchen 17.12.",
+  "content": "Also available in English today.",
+  "sender": {
+    "className": null,
+    "displayName": "Musterlehrer Frank",
+    "imageUrl": null,
+    "userId": 49
+  },
+  "sentDateTime": "2025-12-17T07:11:00",
+  "allowMessageDeletion": true,
+  "attachments": [
+    {
+      "id": "0",
+      "name": "17.12. eng.pdf",
+      "downloadUrl": "https://example-my.sharepoint.invalid/:b:/g/personal/redacted/redacted1"
+    },
+    {
+      "id": "0",
+      "name": "17.12..pdf",
+      "downloadUrl": "https://example-my.sharepoint.invalid/:b:/g/personal/redacted/redacted2"
+    }
+  ],
+  "blobAttachment": null,
+  "storageAttachments": [],
+  "isReply": false,
+  "isReplyAllowed": true,
+  "isReportMessage": false,
+  "isReplyForbidden": false,
+  "replyHistory": [],
+  "requestConfirmation": null
+}

--- a/test/fixtures/specified_message_storage_attachment.json
+++ b/test/fixtures/specified_message_storage_attachment.json
@@ -1,0 +1,27 @@
+{
+  "id": 4857,
+  "subject": "Schulmusical - Termine nächste Woche!",
+  "content": "Liebe Schulgemeinde,\nhier die Ankündigung des Schulmusicals.",
+  "sender": {
+    "className": null,
+    "displayName": "Admin_2",
+    "imageUrl": null,
+    "userId": 145
+  },
+  "sentDateTime": "2026-06-05T15:52:00",
+  "allowMessageDeletion": false,
+  "attachments": [],
+  "blobAttachment": null,
+  "storageAttachments": [
+    {
+      "id": "68d39a3f-7a7d-4aaa-b597-641d6cf121c1",
+      "name": "Schulmusical-Plakat.pdf"
+    }
+  ],
+  "isReply": false,
+  "isReplyAllowed": false,
+  "isReportMessage": false,
+  "isReplyForbidden": false,
+  "replyHistory": [],
+  "requestConfirmation": null
+}

--- a/test/fixtures/timetable_entries.json
+++ b/test/fixtures/timetable_entries.json
@@ -1,0 +1,88 @@
+{
+  "format": 1,
+  "days": [
+    {
+      "date": "2026-08-17",
+      "resourceType": "STUDENT",
+      "resource": {
+        "id": 4379,
+        "shortName": "musterschueler",
+        "longName": "Mustermann",
+        "displayName": ""
+      },
+      "status": "REGULAR",
+      "dayEntries": [],
+      "gridEntries": [
+        {
+          "ids": [6575102, 6575105],
+          "duration": {
+            "start": "2026-08-17T08:00",
+            "end": "2026-08-17T09:35"
+          },
+          "type": "NORMAL_TEACHING_PERIOD",
+          "status": "REGULAR",
+          "statusDetail": null,
+          "name": null,
+          "layoutStartPosition": 0,
+          "layoutWidth": 1000,
+          "layoutGroup": 1,
+          "color": "bfc8cf",
+          "notesAll": "",
+          "icons": [],
+          "position1": [
+            {
+              "current": {
+                "type": "TEACHER",
+                "status": "REGULAR",
+                "shortName": "MusL",
+                "longName": "Musterlehrerin",
+                "displayName": "MusL",
+                "displayNameLabel": "NAME"
+              },
+              "removed": null
+            }
+          ],
+          "position2": [
+            {
+              "current": {
+                "type": "SUBJECT",
+                "status": "REGULAR",
+                "shortName": "G",
+                "longName": "Geschichte",
+                "displayName": "G",
+                "displayNameLabel": "NAME"
+              },
+              "removed": null
+            }
+          ],
+          "position3": [
+            {
+              "current": {
+                "type": "ROOM",
+                "status": "REGULAR",
+                "shortName": "14-10",
+                "longName": "14-10",
+                "displayName": "14-10",
+                "displayNameLabel": "NAME"
+              },
+              "removed": null
+            }
+          ],
+          "position4": null,
+          "position5": null,
+          "position6": null,
+          "position7": null,
+          "texts": [],
+          "lessonText": "",
+          "lessonInfo": null,
+          "substitutionText": "",
+          "userName": null,
+          "moved": null,
+          "durationTotal": null,
+          "link": null
+        }
+      ],
+      "backEntries": []
+    }
+  ]
+}

--- a/test/fixtures/user_data.json
+++ b/test/fixtures/user_data.json
@@ -1,0 +1,87 @@
+{
+  "masterData": {
+    "timeStamp": 1786788455112,
+    "klassen": [
+      {
+        "id": 1685,
+        "name": "10A",
+        "longName": "Neßhöfer,Wördemann",
+        "departmentId": 2,
+        "startDate": "2026-08-31",
+        "endDate": "2027-07-18",
+        "foreColor": null,
+        "backColor": null,
+        "active": true,
+        "displayable": false
+      }
+    ],
+    "rooms": [
+      {
+        "id": 1349,
+        "name": "A-06 ",
+        "longName": "Konferenzraum Lehrerzimmer",
+        "departmentId": 0,
+        "foreColor": null,
+        "backColor": null,
+        "active": false,
+        "displayAllowed": false
+      }
+    ],
+    "subjects": [
+      {
+        "id": 1530,
+        "name": "?",
+        "longName": "?",
+        "departmentIds": [],
+        "foreColor": "#000000",
+        "backColor": "#d66b29",
+        "active": true,
+        "displayAllowed": false
+      }
+    ],
+    "teachers": [
+      {
+        "id": 823,
+        "name": "BAL",
+        "firstName": "Anna",
+        "lastName": "Musterlehrer1",
+        "departmentIds": [1],
+        "foreColor": null,
+        "backColor": null,
+        "entryDate": null,
+        "exitDate": null,
+        "active": true,
+        "displayAllowed": false
+      }
+    ],
+    "timeGrid": {
+      "days": [
+        {
+          "day": "MON",
+          "units": [
+            {
+              "label": "1",
+              "startTime": "T07:55",
+              "endTime": "T08:55"
+            },
+            {
+              "label": "2",
+              "startTime": "T09:10",
+              "endTime": "T10:10"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "userData": {
+    "elemType": "CLASS",
+    "elemId": 1664,
+    "displayName": "",
+    "schoolName": "Jugenddorf-Christophorusschule",
+    "departmentId": 1,
+    "children": [],
+    "klassenIds": [],
+    "rights": []
+  }
+}

--- a/test/live/README.md
+++ b/test/live/README.md
@@ -1,0 +1,66 @@
+# Live API coverage tests (tier 4b)
+
+These tests hit the **real** Untis API with **real school credentials**. They exist to answer a
+question fixtures can't: does everything the live server sends today actually parse, and is there
+API surface we don't model at all yet?
+
+They call the same production `request*` functions/providers the app uses — nothing is
+reimplemented — and diff every raw response against the resulting model to flag any field the
+server sent that no `fromJson` picks up.
+
+**Local-only, always.** These tests are never run in CI. They *do* run as part of the Claude Code
+Stop hook's `full` verification level (see `CLAUDE.md`) — but that hook only ever executes on your
+own machine, and without `test/live/credentials.local.json` present these tests just run a trivial
+placeholder and pass instantly, so it's safe to leave that as the default. `dart_test.yaml` tags
+these tests `live` and skips that tag unless explicitly requested.
+
+## Running
+
+```shell
+flutter test --tags=live --run-skipped
+```
+
+Both flags matter: `--tags=live` selects only these tests, and `--run-skipped` is required to
+actually execute them — `dart_test.yaml` marks the `live` tag skip-by-default, and `--tags=live`
+alone doesn't override that (you'd otherwise just get "All tests skipped").
+
+## Providing credentials
+
+Create `test/live/credentials.local.json` (gitignored — never commit this file) with one entry per
+account, e.g.:
+
+```json
+[
+  { "school": "cjd-koewi", "loginMode": "password", "username": "...", "password": "..." },
+  { "school": "bs-gfv", "loginMode": "anonymous" },
+  { "school": "schuldorf", "loginMode": "ssoKey", "username": "...", "key": "..." },
+  { "school": "wolfsburger-oberschule", "loginMode": "password", "username": "...", "password": "..." }
+]
+```
+
+- `school` is passed to the real school search (`searchSchool`) and matched by `loginName` — use
+  the same value you'd type into the school picker.
+- `loginMode` is one of `password`, `ssoKey`, `anonymous` (matches `LoginMode` in
+  `lib/core/untis/untis_session.dart`).
+- `password` mode needs `username` + `password`. `ssoKey` mode needs `username` + `key` (the
+  app-shared-secret/login key itself — what you'd scan from a QR code or paste in by hand).
+  `anonymous` mode needs neither.
+
+All accounts in the list are exercised in one `flutter test --tags=live --run-skipped` run.
+
+Alternatively, set the environment variable `UNTIS_LIVE_CREDENTIALS` to the same JSON (checked
+first, useful for a quick one-off run without creating the file). If neither is present, the test
+suite reports a clear skip instead of failing.
+
+## What gets checked, and what doesn't
+
+For each account: school search, login, `getUserData2017`, `mobile/data`, the messages list *and
+the detail of every single message returned*, timetable entries for the surrounding few weeks, and
+exams — each response is diffed against its model for unrecognized fields, and any exception during
+the whole flow is caught and reported per-section rather than aborting the run, so one broken
+endpoint doesn't hide problems elsewhere.
+
+These tests assert on structure only — counts, key names, types — never on the content of your
+actual school data, and never print or log a raw response body. If a test fails, the failure
+message lists dotted key paths (e.g. `sender.newField`) or exception text, never message content or
+credentials.

--- a/test/live/api_coverage_live_test.dart
+++ b/test/live/api_coverage_live_test.dart
@@ -1,0 +1,266 @@
+@Tags(['live'])
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:your_schedule/core/rpc_request/rpc.dart';
+import 'package:your_schedule/core/untis.dart';
+import 'package:your_schedule/util/week.dart';
+
+import '../support/json_parity.dart';
+import '../support/test_shared_preferences.dart';
+import 'capturing_client.dart';
+import 'known_gaps.dart';
+import 'live_credentials.dart';
+
+/// Exhaustively exercises the real Untis API with real accounts to answer two
+/// questions: does everything parse without throwing, and is there API surface we
+/// don't model yet (a field the server sends that no `fromJson` picks up)? This
+/// drives the actual production `request*` functions/providers — not reimplemented
+/// HTTP calls — through a plain [ProviderContainer], and diffs every raw response
+/// against the resulting model via [findUnparsedKeys].
+///
+/// Local-only, real credentials required: see `test/live/README.md`. Never wired
+/// into CI. Runs as part of the Claude Code Stop hook's `full` verification level
+/// (safe without credentials — see `test/live/README.md`); `dart_test.yaml` skips
+/// the `live` tag unless `--run-skipped` is passed.
+void main() {
+  final credentials = loadLiveCredentials();
+
+  if (credentials.isEmpty) {
+    test('live credentials configured', () {}, skip: 'No live credentials found — see test/live/README.md.');
+    return;
+  }
+
+  for (final credential in credentials) {
+    test('${credential.schoolSearch}: full API coverage', () async {
+      await initTestSharedPreferences();
+      final problems = <String>[];
+
+      stdout.writeln('=== ${credential.schoolSearch} (${credential.loginMode.name}) ===');
+
+      final log = ExchangeLog();
+
+      // Each section gets its own short-lived ProviderContainer, disposed right
+      // after — sections must stay isolated from each other. A shared container
+      // across the whole flow meant one section's provider ending up in an error
+      // state could cascade into "ProviderContainer already disposed"/hangs for
+      // every section after it, once package:test's zone-level error handling
+      // kicked in and started tearing down early.
+      Future<void> section(String label, Future<void> Function(ProviderContainer) body) async {
+        final sectionContainer = ProviderContainer();
+        // Deferred to the whole test's teardown, not disposed right after body()
+        // returns: the "live vs cached" pattern's listenSelf (CLAUDE.md) kicks off
+        // a detached cache-write side effect that isn't awaited by — and can
+        // outlive — the .future body() awaits. Disposing immediately raced that
+        // write, intermittently throwing "Cannot use the Ref of
+        // cachedTimeTableProvider(...), the associated container was disposed".
+        addTearDown(sectionContainer.dispose);
+        try {
+          // Bounded so one stuck section can't eat the whole run — observed: a
+          // provider whose build() threw a non-2xx HTTP/RPC error would sometimes
+          // never settle its .future in this test harness (root cause not pinned
+          // down; ruled out Sentry.captureException in logRequestError() — its
+          // NoOpHub, active whenever SentryFlutter.init() hasn't run, resolves
+          // immediately, so that's not it).
+          await body(sectionContainer).timeout(const Duration(seconds: 20));
+        } catch (e) {
+          stdout.writeln('  ✗ $label: threw $e');
+          problems.add('$label: threw $e');
+        }
+      }
+
+      // Prints one line per endpoint checked — status code, method+path, and
+      // whether every key in the response was recognized. Counts/paths only, never
+      // response content, per test/live/README.md. Unparsed keys already recorded
+      // in known_gaps.dart are reported but don't fail the run — only a *new* gap
+      // (something that showed up today and isn't already tracked) does.
+      void checkParity(String label, dynamic raw, Object? model, {Set<String> knownGaps = const {}}) {
+        final exchange = log.last;
+        final unparsed = findUnparsedKeys(raw, model);
+        final newGaps = unparsed.where((k) => !knownGaps.contains(normalizeKeyPath(k))).toList();
+        final outcome = switch ((unparsed.length, newGaps.length)) {
+          (0, _) => 'OK',
+          (final total, 0) => '$total known unparsed key(s)',
+          (final total, final fresh) => '$fresh NEW unparsed key(s) (of $total total)',
+        };
+        stdout.writeln('  [${exchange.statusCode}] ${exchange.requestLabel} — $label: $outcome');
+        if (newGaps.isNotEmpty) {
+          problems.add('$label: ${newGaps.length} new unparsed key(s): ${newGaps.join(', ')}');
+        }
+      }
+
+      final schoolSearchContainer = ProviderContainer();
+      addTearDown(schoolSearchContainer.dispose);
+
+      await http.runWithClient(() async {
+        // 1. School search — also exercises requestSchoolList's parser.
+        final schools = await schoolSearchContainer.read(requestSchoolListProvider(credential.schoolSearch).future);
+        expect(schools, isNotEmpty, reason: 'schoolsearch returned no match for "${credential.schoolSearch}"');
+        stdout.writeln(
+          '  [${log.last.statusCode}] ${log.last.requestLabel} — school search: found ${schools.length}',
+        );
+        final school = schools.firstWhere(
+          (s) => s.loginName == credential.schoolSearch,
+          orElse: () => schools.first,
+        );
+
+        // 2. Login, per LoginMode — obtains userData (getUserData2017).
+        UserData userData;
+        String? appSharedSecret;
+        switch (credential.loginMode) {
+          case LoginMode.password:
+            appSharedSecret = await requestAppSharedSecret(
+              school,
+              credential.username!,
+              credential.password!,
+            );
+            stdout.writeln('  [${log.last.statusCode}] ${log.last.requestLabel} — app-shared-secret: OK');
+            userData = await requestUserData(
+              school,
+              AuthParams.credentials(user: credential.username!, appSharedSecret: appSharedSecret),
+            );
+          case LoginMode.ssoKey:
+            appSharedSecret = credential.key;
+            userData = await requestUserData(
+              school,
+              AuthParams.credentials(user: credential.username!, appSharedSecret: appSharedSecret!),
+            );
+          case LoginMode.anonymous:
+            userData = await requestUserData(school, const AuthParams.anonymous());
+        }
+        // getUserData2017's raw body was the *last* RPC exchange right above.
+        // requestUserData() (see request_user_data.dart) only ever hands UserData
+        // the RPC envelope's `result` — diff against that, not the whole envelope,
+        // or `jsonrpc`/`id`/`result` show up as false-positive "unparsed" fields.
+        final userDataRaw = jsonDecode(log.last.responseBody);
+        checkParity(
+          'userData',
+          userDataRaw is Map ? userDataRaw['result'] : userDataRaw,
+          userData,
+          knownGaps: userDataKnownGaps,
+        );
+
+        final session = UntisSession.active(
+          school,
+          credential.loginMode,
+          credential.username,
+          null,
+          appSharedSecret,
+          userData,
+        ) as ActiveUntisSession;
+
+        // 3. mobile/data.
+        await section('mobile/data', (container) async {
+          final mobileData = await container.read(requestMobileDataProvider(session).future);
+          checkParity('mobile/data', jsonDecode(log.last.responseBody), mobileData);
+        });
+
+        // 4. Messages list, then — the case that matters most — the detail of
+        //    *every* message returned. Content is the most heterogeneous data in the
+        //    API, so this is the most likely place to catch a field the server added
+        //    that SpecifiedMessage doesn't know about yet.
+        //
+        //    Skipped for anonymous accounts: confirmed (via live testing against
+        //    bs-gfv) that the server returns 403 Forbidden for anonymous sessions on
+        //    both the list and detail endpoints — a genuine, permanent authorization
+        //    boundary, not a bug. RequestMessages/RequestSpecifiedMessage now assert
+        //    against being called with an anonymous session, so calling them here
+        //    would just trip that assert instead of exercising anything new.
+        if (credential.loginMode == LoginMode.anonymous) {
+          stdout.writeln('  – messages: skipped (not available for anonymous sessions)');
+        } else {
+          await section('messages', (container) async {
+            final messages = await container.read(requestMessagesProvider(session).future);
+            checkParity(
+              'messages list (${messages.incomingMessages.length} messages)',
+              jsonDecode(log.last.responseBody),
+              messages,
+            );
+
+            for (final message in messages.incomingMessages) {
+              await section('message ${message.id} detail', (container) async {
+                final detail = await container.read(
+                  requestSpecifiedMessageProvider(session, message.id).future,
+                );
+                checkParity('message ${message.id} detail', jsonDecode(log.last.responseBody), detail);
+              });
+            }
+          });
+        }
+
+        // 5 & 6 need a resource (elemType/id) to ask the server for a timetable or
+        // exams against. Some anonymous accounts (confirmed live against bs-gfv) come
+        // back from getUserData2017 with a null elemType/id — the server has no
+        // resource on file for them — which is a genuine, permanent per-account data
+        // gap, not a bug: request_timetable_entries.dart already guards this
+        // client-side with a clear StateError, and getExams2017 just hangs
+        // server-side when asked with a null/-1 id instead of erroring. Skip both
+        // sections rather than let either show up as a "problem".
+        final hasTimetableResource = session.userData.type != null;
+
+        // 5. Timetable entries, current week +/- 1.
+        if (!hasTimetableResource) {
+          stdout.writeln('  – timetable entries: skipped (userData.elemType is null for this session)');
+        } else {
+          for (final relative in [-1, 0, 1]) {
+            final week = Week.relative(relative);
+            await section('timetable entries ($week)', (container) async {
+              await container.read(requestTimetableEntriesProvider(session, week).future);
+              if (log.last.statusCode == 200) {
+                // TimetableEntriesResponse isn't exposed by the provider (it returns
+                // a day-keyed Map) — re-decode raw against the day list shape by
+                // re-parsing the same JSON through the model directly.
+                final raw = jsonDecode(log.last.responseBody);
+                final reparsed = TimetableEntriesResponse.fromJson(raw as Map<String, dynamic>);
+                checkParity('timetable entries ($week)', raw, reparsed, knownGaps: timetableEntriesKnownGaps);
+              } else {
+                // A 404 ("no data for this range") is handled internally and makes
+                // no model to diff against — still worth a line, so the report shows
+                // every week that was actually checked.
+                stdout.writeln(
+                  '  [${log.last.statusCode}] ${log.last.requestLabel} — timetable entries ($week): no data',
+                );
+              }
+            });
+          }
+        }
+
+        // 6. Exams, current week.
+        if (!hasTimetableResource) {
+          stdout.writeln('  – exams: skipped (userData.elemType is null for this session)');
+        } else {
+          await section('exams', (container) async {
+            await container.read(requestExamsProvider(session, Week.now()).future);
+            // getExams2017's raw envelope's `result` (not the whole envelope) is what
+            // Exam.fromJson consumes per-item; spot-check the envelope shape itself
+            // isn't silently missing top-level keys.
+            final raw = jsonDecode(log.last.responseBody);
+            if (raw is Map && raw['result'] is Map) {
+              final examsRaw = (raw['result'] as Map)['exams'] as List<dynamic>;
+              stdout.writeln(
+                '  [${log.last.statusCode}] ${log.last.requestLabel} — exams: ${examsRaw.length} exam(s)',
+              );
+              for (var i = 0; i < examsRaw.length; i++) {
+                final examJson = examsRaw[i] as Map<String, dynamic>;
+                checkParity('exam[$i]', examJson, Exam.fromJson(examJson));
+              }
+            }
+          });
+        }
+      }, () => CapturingClient(log));
+
+      stdout.writeln(
+        problems.isEmpty
+            ? '  ✓ ${credential.schoolSearch}: all endpoints checked cleanly'
+            : '  ✗ ${credential.schoolSearch}: ${problems.length} problem(s) found',
+      );
+
+      expect(problems, isEmpty, reason: problems.join('\n'));
+    }, timeout: const Timeout(Duration(minutes: 3)));
+  }
+}

--- a/test/live/capturing_client.dart
+++ b/test/live/capturing_client.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// One request/response pair observed by a [CapturingClient].
+class CapturedExchange {
+  final Uri url;
+  final String method;
+  final int statusCode;
+  final String responseBody;
+  final String? requestBody;
+
+  const CapturedExchange(this.url, this.method, this.statusCode, this.responseBody, this.requestBody);
+
+  /// A short, human-readable label for this exchange — the JSON-RPC `method` for RPC
+  /// POSTs (which all share the same URL, so the URL alone isn't distinguishing), or
+  /// the REST method + path otherwise. Used only for printing which endpoints a live
+  /// test run touched — never includes request/response content.
+  String get requestLabel {
+    final body = requestBody;
+    // A GET's request.body is '' (empty string), not null — must check both, or
+    // jsonDecode('') throws "Unexpected end of input".
+    if (body != null && body.isNotEmpty) {
+      final decoded = jsonDecode(body);
+      if (decoded is Map && decoded['method'] is String) {
+        return 'RPC ${decoded['method']}';
+      }
+    }
+    return '$method ${url.path}';
+  }
+}
+
+/// Shared, long-lived record of every exchange seen across a whole
+/// `http.runWithClient` session. Needed because `package:http`'s top-level
+/// convenience functions (`http.get`/`http.post`, which every production request
+/// function here uses) call the `clientFactory` passed to `runWithClient` fresh for
+/// *every single call* and close whatever it returns immediately after — see
+/// `_withClient` in `package:http/http.dart`. A [CapturingClient] instance is
+/// therefore one-shot; this log is what survives across the whole flow.
+class ExchangeLog {
+  final List<CapturedExchange> exchanges = [];
+
+  /// The most recently completed exchange — call this immediately after `await`ing
+  /// the production call under test, since exchanges are recorded in request order.
+  CapturedExchange get last => exchanges.last;
+}
+
+/// A real [http.Client] (backed by the platform's default client) that also records
+/// every request/response pair it sees into a shared [ExchangeLog], so live tests
+/// can run the actual production request functions unmodified and still get at the
+/// raw exchange afterwards — needed to run [findUnparsedKeys]
+/// (see `test/support/json_parity.dart`) against what the real API just returned,
+/// and to report which endpoint was checked.
+///
+/// One-shot by design (see [ExchangeLog]) — pass `() => CapturingClient(log)` as
+/// `runWithClient`'s `clientFactory`, not a single shared instance, or the second
+/// request will throw "Client is already closed".
+class CapturingClient extends http.BaseClient {
+  CapturingClient(this._log);
+
+  final ExchangeLog _log;
+  final http.Client _inner = http.Client();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await _inner.send(request);
+    final bytes = await response.stream.toBytes();
+    _log.exchanges.add(
+      CapturedExchange(
+        request.url,
+        request.method,
+        response.statusCode,
+        utf8.decode(bytes),
+        request is http.Request ? request.body : null,
+      ),
+    );
+    return http.StreamedResponse(
+      Stream.value(bytes),
+      response.statusCode,
+      contentLength: bytes.length,
+      request: response.request,
+      headers: response.headers,
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/test/live/known_gaps.dart
+++ b/test/live/known_gaps.dart
@@ -1,0 +1,78 @@
+/// Known-unmodeled API fields, one set per endpoint, checked against the *live*
+/// API's actual responses (see `api_coverage_live_test.dart`). Paths are normalized
+/// via `normalizeKeyPath` (array indices collapsed to `[]`), so these stay a fixed
+/// size regardless of how many klassen/rooms/subjects/etc. a given school has.
+///
+/// This list exists so the live-coverage test can tell "field we've never modeled,
+/// already known about" apart from "field that showed up today for the first
+/// time" — only the latter should ever fail a run. Last verified against real
+/// responses from all four credentialed schools on 2026-08-17 (see
+/// docs/api/spec/NOTES.md for what each school represents). Adding something here
+/// should come with a reason; removing something here (because a model started
+/// capturing it) is a good sign, not a bug.
+library;
+
+/// `getUserData2017` — deliberately-partial by design (see
+/// `lib/core/untis/models/user_data/user_data.dart`): only pulls the subset of
+/// master data any screen currently needs.
+const userDataKnownGaps = <String>{
+  // Whole master-data categories never modeled at all.
+  'masterData.absenceReasons',
+  'masterData.departments',
+  'masterData.duties',
+  'masterData.eventReasons',
+  'masterData.eventReasonGroups',
+  'masterData.excuseStatuses',
+  'masterData.teachingMethods',
+  'masterData.schoolyears',
+  // Per-item fields on klassen/rooms/subjects/teachers not modeled — color
+  // theming and department scoping aren't used anywhere in the UI today.
+  'masterData.klassen[].departmentId',
+  'masterData.klassen[].foreColor',
+  'masterData.klassen[].backColor',
+  'masterData.rooms[].departmentId',
+  'masterData.rooms[].foreColor',
+  'masterData.rooms[].backColor',
+  'masterData.rooms[].displayAllowed',
+  'masterData.subjects[].departmentIds',
+  'masterData.subjects[].foreColor',
+  'masterData.subjects[].backColor',
+  'masterData.subjects[].displayAllowed',
+  'masterData.teachers[].departmentIds',
+  'masterData.teachers[].foreColor',
+  'masterData.teachers[].backColor',
+  'masterData.teachers[].entryDate',
+  'masterData.teachers[].exitDate',
+  'masterData.teachers[].displayAllowed',
+  // UserData.fromJson only reads the *first* timeGrid day's units (see its
+  // doc comment) — every other day, and each day's own `day` label, is dropped.
+  'masterData.timeGrid.days[].day',
+  'masterData.timeGrid.days[].units',
+  // userData block: only elemType/elemId/displayName/schoolName are read.
+  'userData.departmentId',
+  'userData.children',
+  'userData.klassenIds',
+  'userData.rights',
+  // The whole `settings` block (absence-check defaults, calendar display prefs)
+  // is unused by the app today.
+  'settings',
+};
+
+/// `GET /timetable/entries` — see `lib/core/untis/models/timetable/grid_entry.dart`
+/// and `timetable_entries_response.dart`.
+const timetableEntriesKnownGaps = <String>{
+  // Always empty in every capture so far; shape/purpose unconfirmed (see
+  // docs/api/spec/NOTES.md §3).
+  'days[].dayEntries',
+  'days[].backEntries',
+  // Observed on real gridEntries but not yet in GridEntry — `name` is
+  // consistently null so far; the other four have never been captured non-null.
+  'days[].gridEntries[].name',
+  'days[].gridEntries[].userName',
+  'days[].gridEntries[].moved',
+  'days[].gridEntries[].durationTotal',
+  'days[].gridEntries[].link',
+  // A top-level `errors` field observed live, never in any doc capture — shape
+  // unknown (was empty/absent-looking in every observed response so far).
+  'errors',
+};

--- a/test/live/live_credentials.dart
+++ b/test/live/live_credentials.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:your_schedule/core/untis.dart';
+
+/// One account to exercise the live API with. [schoolSearch] is passed to the real
+/// `searchSchool` RPC (same as the login screen would use) — the school matching
+/// [schoolSearch] as its `loginName` is picked from the results.
+class LiveCredential {
+  final String schoolSearch;
+  final LoginMode loginMode;
+  final String? username;
+  final String? password;
+
+  /// The app-shared-secret itself, for [LoginMode.ssoKey].
+  final String? key;
+
+  const LiveCredential({
+    required this.schoolSearch,
+    required this.loginMode,
+    this.username,
+    this.password,
+    this.key,
+  });
+
+  factory LiveCredential.fromJson(Map<String, dynamic> json) {
+    return LiveCredential(
+      schoolSearch: json['school'] as String,
+      loginMode: LoginMode.values.byName(json['loginMode'] as String),
+      username: json['username'] as String?,
+      password: json['password'] as String?,
+      key: json['key'] as String?,
+    );
+  }
+}
+
+/// Loads the accounts to test against, checking `UNTIS_LIVE_CREDENTIALS` (a JSON
+/// array, for quick one-off shell invocations) before falling back to the gitignored
+/// `test/live/credentials.local.json`. Returns an empty list if neither is present —
+/// callers should skip rather than fail in that case. See `test/live/README.md`.
+List<LiveCredential> loadLiveCredentials() {
+  final envJson = Platform.environment['UNTIS_LIVE_CREDENTIALS'];
+  String? raw;
+  if (envJson != null && envJson.trim().isNotEmpty) {
+    raw = envJson;
+  } else {
+    final file = File('test/live/credentials.local.json');
+    if (file.existsSync()) {
+      raw = file.readAsStringSync();
+    }
+  }
+  if (raw == null) {
+    return [];
+  }
+  final decoded = jsonDecode(raw) as List<dynamic>;
+  return decoded.map((e) => LiveCredential.fromJson(e as Map<String, dynamic>)).toList();
+}

--- a/test/requests/request_exams_test.dart
+++ b/test/requests/request_exams_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:your_schedule/core/untis.dart';
+import 'package:your_schedule/util/week.dart';
+
+import '../support/fixtures.dart';
+import '../support/test_shared_preferences.dart';
+
+void main() {
+  setUp(initTestSharedPreferences);
+
+  test('requestExams parses a real empty-exams RPC response', () async {
+    // Regression test: this used to throw a NoSuchMethodError at runtime
+    // (`response.result.result['exams']` — a stray double `.result`) for every
+    // exams request, real data or not. See request_exams.dart.
+    final school = School.fromJson(loadFixtureMap('school.json'));
+    final userData = UserData.fromJson(loadFixtureMap('user_data.json'));
+
+    final mockClient = MockClient((request) async {
+      final requestBody = jsonDecode(request.body) as Map<String, dynamic>;
+      final template = loadFixtureMap('exams_rpc_response_empty.json');
+      return http.Response(
+        jsonEncode({...template, 'id': requestBody['id']}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+
+    final activeSession = UntisSession.active(
+      school,
+      LoginMode.anonymous,
+      null,
+      null,
+      null,
+      userData,
+    ) as ActiveUntisSession;
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final examsByDay = await http.runWithClient(
+      () => container.read(requestExamsProvider(activeSession, Week.now()).future),
+      () => mockClient,
+    );
+
+    expect(examsByDay, hasLength(7));
+    expect(examsByDay.values.every((exams) => exams.isEmpty), isTrue);
+  });
+}

--- a/test/requests/request_login_meta_test.dart
+++ b/test/requests/request_login_meta_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../support/fixtures.dart';
+
+void main() {
+  test('requestLoginMeta hits login-meta and parses the response', () async {
+    final school = School.fromJson(loadFixtureMap('school.json'));
+
+    final mockClient = MockClient((request) async {
+      expect(request.method, 'GET');
+      expect(request.url.path, '/WebUntis/api/public/v1/login-meta');
+      expect(request.url.queryParameters['school'], 'cjd-koewi');
+      return http.Response(
+        loadFixtureRaw('login_meta.json'),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final loginMeta = await http.runWithClient(
+      () => container.read(requestLoginMetaProvider(school).future),
+      () => mockClient,
+    );
+
+    expect(loginMeta.ssoLoginEnabled, isTrue);
+    expect(loginMeta.anonymousLoginEnabled, isFalse);
+  });
+}

--- a/test/requests/request_school_list_test.dart
+++ b/test/requests/request_school_list_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../support/fixtures.dart';
+
+void main() {
+  test('requestSchoolList parses a real searchSchool RPC response', () async {
+    final mockClient = MockClient((request) async {
+      final requestBody = jsonDecode(request.body) as Map<String, dynamic>;
+      final template = loadFixtureMap('school_search_rpc_response.json');
+      return http.Response(
+        jsonEncode({...template, 'id': requestBody['id']}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final schools = await http.runWithClient(
+      () => container.read(requestSchoolListProvider('cjd').future),
+      () => mockClient,
+    );
+
+    expect(schools, hasLength(1));
+    expect(schools.single.loginName, 'cjd-koewi');
+  });
+}

--- a/test/support/fixtures.dart
+++ b/test/support/fixtures.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Raw (undecoded) contents of `test/fixtures/[name]`. Paths are resolved relative to
+/// the repo root, which is `flutter test`'s working directory.
+String loadFixtureRaw(String name) {
+  return File('test/fixtures/$name').readAsStringSync();
+}
+
+/// Loads and decodes a JSON fixture from `test/fixtures/[name]`. Paths are resolved
+/// relative to the repo root, which is `flutter test`'s working directory.
+dynamic loadFixture(String name) {
+  return jsonDecode(loadFixtureRaw(name));
+}
+
+/// [loadFixture], typed as a `Map` — the common case for a single JSON object.
+Map<String, dynamic> loadFixtureMap(String name) {
+  return loadFixture(name) as Map<String, dynamic>;
+}

--- a/test/support/json_parity.dart
+++ b/test/support/json_parity.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+/// Recursively diffs [raw] (decoded API JSON) against [model] by round-tripping
+/// [model] through `jsonEncode`/`jsonDecode`, and returns dotted-path keys present in
+/// [raw] but absent from that round-trip — i.e. fields the model silently drops.
+///
+/// Routing [model] through `jsonEncode` (rather than calling `.toJson()` and diffing
+/// directly) normalizes nested Freezed objects to plain `Map`/`List` regardless of
+/// whether a given model's `toJson` uses `explicitToJson`, so this works uniformly
+/// across the model set. An empty result means every key the server sent is
+/// represented somewhere in the model; a non-empty result flags API surface this
+/// codebase doesn't parse yet — intentional gaps should be recorded as an explicit
+/// allow-list at the call site (see model test files) so *new* gaps still fail loudly.
+List<String> findUnparsedKeys(dynamic raw, Object? model) {
+  final reencoded = jsonDecode(jsonEncode(model));
+  return _diff(raw, reencoded, '');
+}
+
+/// Collapses list indices in a [findUnparsedKeys] path (`klassen[42].foreColor` →
+/// `klassen[].foreColor`) so a known-gap allow-list stays a fixed size regardless of
+/// how many items a real API response happens to contain — needed for live data
+/// (unlike small hand-written fixtures, a real school's `klassen`/`rooms`/`subjects`
+/// list length varies per account).
+String normalizeKeyPath(String path) => path.replaceAll(RegExp(r'\[\d+\]'), '[]');
+
+List<String> _diff(dynamic raw, dynamic reencoded, String path) {
+  final missing = <String>[];
+  if (raw is Map) {
+    final re = reencoded is Map ? reencoded : const {};
+    for (final entry in raw.entries) {
+      final key = entry.key.toString();
+      final childPath = path.isEmpty ? key : '$path.$key';
+      if (!re.containsKey(key)) {
+        missing.add(childPath);
+      } else {
+        missing.addAll(_diff(entry.value, re[key], childPath));
+      }
+    }
+  } else if (raw is List) {
+    final re = reencoded is List ? reencoded : const [];
+    for (var i = 0; i < raw.length; i++) {
+      missing.addAll(_diff(raw[i], i < re.length ? re[i] : null, '$path[$i]'));
+    }
+  }
+  return missing;
+}

--- a/test/support/test_shared_preferences.dart
+++ b/test/support/test_shared_preferences.dart
@@ -1,0 +1,21 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:your_schedule/util/shared_preferences.dart';
+
+bool _initialized = false;
+
+/// Initializes the app's global [sharedPreferences] against an in-memory fake.
+///
+/// Needed by any test that reads a `request*` provider using the "live vs. cached"
+/// pattern (see CLAUDE.md) — those write to [sharedPreferences] as a side effect via
+/// `listenSelf`, which otherwise throws `LateInitializationError` outside a real app
+/// bootstrap (normally done once in `main()`). Safe to call more than once per test
+/// file/isolate — [sharedPreferences] is a `late final`, so only the first call
+/// actually initializes it.
+Future<void> initTestSharedPreferences() async {
+  if (_initialized) {
+    return;
+  }
+  SharedPreferences.setMockInitialValues({});
+  await initSharedPreferences();
+  _initialized = true;
+}

--- a/test/unit/models/exam_test.dart
+++ b/test/unit/models/exam_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses an exam item, all fields round-trip', () {
+    // No capture ever observed a populated `exams` array (see
+    // docs/api/spec/NOTES.md §3) — this fixture is hand-constructed to match the
+    // `Exam`/`Invigilators` models' own fields, not derived from a real response.
+    // It only proves the model parses its own shape correctly; the live coverage
+    // test (test/live/) is what actually validates this against the real API.
+    final raw = loadFixtureMap('exam_item_synthetic.json');
+
+    final exam = Exam.fromJson(raw);
+
+    expect(exam.id, 501);
+    expect(exam.subjectId, 1530);
+    expect(exam.invigilators, hasLength(1));
+    expect(exam.invigilators.single.startTime.hour, 7);
+    expect(findUnparsedKeys(raw, exam.toJson()), isEmpty);
+  });
+}

--- a/test/unit/models/login_meta_test.dart
+++ b/test/unit/models/login_meta_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real login-meta response with no unrecognized fields', () {
+    final raw = loadFixtureMap('login_meta.json');
+
+    final loginMeta = LoginMeta.fromJson(raw);
+
+    expect(loginMeta.anonymousLoginEnabled, isFalse);
+    expect(loginMeta.ssoLoginEnabled, isTrue);
+    expect(findUnparsedKeys(raw, loginMeta.toJson()), isEmpty);
+  });
+}

--- a/test/unit/models/messages_test.dart
+++ b/test/unit/models/messages_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real messages-list response with no unrecognized fields', () {
+    final raw = loadFixtureMap('messages.json');
+
+    final messages = Messages.fromJson(raw);
+
+    expect(messages.incomingMessages, hasLength(2));
+    expect(messages.incomingMessages.first.id, 4890);
+    expect(messages.incomingMessages.first.sender.displayName, 'Admin_1');
+    expect(messages.incomingMessages[1].hasAttachments, isTrue);
+    expect(findUnparsedKeys(raw, messages.toJson()), isEmpty);
+  });
+}

--- a/test/unit/models/school_test.dart
+++ b/test/unit/models/school_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real school-search result, known gaps only', () {
+    final raw = loadFixtureMap('school.json');
+
+    final school = School.fromJson(raw);
+
+    expect(school.loginName, 'cjd-koewi');
+    expect(school.server, 'cjd-koewi.webuntis.com');
+    expect(school.rpcUrl, 'https://cjd-koewi.webuntis.com/WebUntis/jsonrpc_intern.do?school=cjd-koewi');
+
+    // Known, currently-unmodeled fields — not used anywhere in the app today.
+    // A new key showing up here (not in this list) means the API added something
+    // `School` might actually need.
+    expect(
+      findUnparsedKeys(raw, school.toJson()),
+      unorderedEquals(<String>[
+        'useMobileServiceUrlAndroid',
+        'useMobileServiceUrlIos',
+        'tenantId',
+        'mobileServiceUrl',
+      ]),
+    );
+  });
+}

--- a/test/unit/models/specified_message_test.dart
+++ b/test/unit/models/specified_message_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real message detail with an S3-backed (storage) attachment', () {
+    final raw = loadFixtureMap('specified_message_storage_attachment.json');
+
+    final message = SpecifiedMessage.fromJson(raw);
+
+    expect(message.id, 4857);
+    expect(message.storageAttachments, hasLength(1));
+    expect(message.storageAttachments.first.name, 'Schulmusical-Plakat.pdf');
+    expect(message.attachments, isEmpty);
+    expect(findUnparsedKeys(raw, message.toJson()), isEmpty);
+  });
+
+  test('parses a real message detail with an externally-hosted attachment', () {
+    final raw = loadFixtureMap('specified_message_external_attachment.json');
+
+    final message = SpecifiedMessage.fromJson(raw);
+
+    expect(message.id, 11743);
+    expect(message.attachments, hasLength(2));
+    expect(message.storageAttachments, isEmpty);
+    expect(findUnparsedKeys(raw, message.toJson()), isEmpty);
+  });
+}

--- a/test/unit/models/timetable_entries_test.dart
+++ b/test/unit/models/timetable_entries_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real timetable/entries response, known gaps only', () {
+    final raw = loadFixtureMap('timetable_entries.json');
+
+    final response = TimetableEntriesResponse.fromJson(raw);
+
+    expect(response.days, hasLength(1));
+    final day = response.days.single;
+    expect(day.gridEntries, hasLength(1));
+    final entry = day.gridEntries.single;
+    expect(entry.positionOfType('SUBJECT')?.current.shortName, 'G');
+    expect(entry.positionOfType('TEACHER')?.current.shortName, 'MusL');
+    expect(entry.isCancelled, isFalse);
+    expect(entry.hasSubstitution, isFalse);
+
+    // Known, currently-unmodeled fields observed live on `TimetableDay`/`GridEntry`
+    // (see docs/api/captures/home/timetable_entries.md). A new key here means the
+    // API grew something these models should probably start capturing.
+    expect(
+      findUnparsedKeys(raw, response.toJson()),
+      unorderedEquals(<String>[
+        'days[0].dayEntries',
+        'days[0].backEntries',
+        'days[0].gridEntries[0].name',
+        'days[0].gridEntries[0].userName',
+        'days[0].gridEntries[0].moved',
+        'days[0].gridEntries[0].durationTotal',
+        'days[0].gridEntries[0].link',
+      ]),
+    );
+  });
+}

--- a/test/unit/models/user_data_test.dart
+++ b/test/unit/models/user_data_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/untis.dart';
+
+import '../../support/fixtures.dart';
+import '../../support/json_parity.dart';
+
+void main() {
+  test('parses a real (trimmed) getUserData2017 response, known gaps only', () {
+    final raw = loadFixtureMap('user_data.json');
+
+    final userData = UserData.fromJson(raw);
+
+    expect(userData.id, 1664);
+    expect(userData.type, 'CLASS');
+    expect(userData.klassen.values.single.name, '10A');
+    expect(userData.rooms.values.single.name, 'A-06 ');
+    expect(userData.subjects.values.single.longName, '?');
+    expect(userData.teachers.values.single.shortName, 'BAL');
+    expect(userData.timeGrid, hasLength(2));
+
+    // `UserData.fromJson`/`toJson` are hand-written (not generated — see
+    // `lib/core/untis/models/user_data/user_data.dart`) and deliberately only pick
+    // out a subset of `getUserData2017`'s master data. Known, currently-dropped
+    // fields — a new key here means the API grew something worth capturing, or that
+    // `UserData` started dropping something it used to keep. (Each item's `id` is
+    // *not* a gap — `toJson` reconstructs it from the enclosing map's key.)
+    expect(
+      findUnparsedKeys(raw, userData.toJson()),
+      unorderedEquals(<String>[
+        'masterData.klassen[0].departmentId',
+        'masterData.klassen[0].foreColor',
+        'masterData.klassen[0].backColor',
+        'masterData.rooms[0].departmentId',
+        'masterData.rooms[0].foreColor',
+        'masterData.rooms[0].backColor',
+        'masterData.rooms[0].displayAllowed',
+        'masterData.subjects[0].departmentIds',
+        'masterData.subjects[0].foreColor',
+        'masterData.subjects[0].backColor',
+        'masterData.subjects[0].displayAllowed',
+        'masterData.teachers[0].departmentIds',
+        'masterData.teachers[0].foreColor',
+        'masterData.teachers[0].backColor',
+        'masterData.teachers[0].entryDate',
+        'masterData.teachers[0].exitDate',
+        'masterData.teachers[0].displayAllowed',
+        'masterData.timeGrid.days[0].day',
+        'userData.departmentId',
+        'userData.children',
+        'userData.klassenIds',
+        'userData.rights',
+      ]),
+    );
+  });
+}

--- a/test/unit/rpc/rpc_response_test.dart
+++ b/test/unit/rpc/rpc_response_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/core/rpc_request/rpc.dart';
+
+import '../../support/fixtures.dart';
+
+void main() {
+  test('parses a real successful RPC envelope', () {
+    final raw = loadFixtureMap('exams_rpc_response_empty.json');
+
+    final response = RPCResponse.fromJson(raw);
+
+    expect(response, isA<RPCResponseResult>());
+    final result = response as RPCResponseResult;
+    expect(result.id, '0');
+    expect((result.result as Map<String, dynamic>)['exams'], isEmpty);
+  });
+
+  test('parses an RPC error envelope', () {
+    final json = {
+      'jsonrpc': '2.0',
+      'id': '0',
+      'error': {
+        'code': RPCError.authenticationFailed,
+        'message': 'Login failed',
+        'data': null,
+      },
+    };
+
+    final response = RPCResponse.fromJson(json);
+
+    expect(response, isA<RPCResponseError>());
+    final error = response as RPCResponseError;
+    expect(error.error.code, RPCError.authenticationFailed);
+    expect(error.error.message, 'Login failed');
+  });
+}

--- a/test/unit/util/date_test.dart
+++ b/test/unit/util/date_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/util/date.dart';
+
+void main() {
+  test('equality and comparison are by calendar day, not by time-of-day', () {
+    final a = Date(DateTime(2026, 3, 5, 8));
+    final b = Date(DateTime(2026, 3, 5, 23));
+
+    expect(a, equals(b));
+    expect(a.compareTo(b), 0);
+  });
+
+  test('addDays/subtractDays roll over month and year boundaries', () {
+    final date = Date.raw(2026, 12, 31);
+
+    expect(date.addDays(1), equals(Date.raw(2027, 1, 1)));
+    expect(Date.raw(2026, 1, 1).subtractDays(1), equals(Date.raw(2025, 12, 31)));
+  });
+
+  test('startOfWeek/endOfWeek anchor the week on Saturday', () {
+    // 2026-03-05 is a Thursday.
+    final thursday = Date.raw(2026, 3, 5);
+
+    expect(thursday.startOfWeek(), equals(Date.raw(2026, 2, 28)));
+    expect(thursday.endOfWeek(), equals(Date.raw(2026, 3, 6)));
+  });
+
+  test('differenceInDays is symmetric around zero', () {
+    final start = Date.raw(2026, 3, 1);
+    final end = Date.raw(2026, 3, 10);
+
+    expect(end.differenceInDays(start), 9);
+    expect(start.differenceInDays(end), -9);
+  });
+}

--- a/test/unit/util/week_test.dart
+++ b/test/unit/util/week_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_schedule/util/date.dart';
+import 'package:your_schedule/util/week.dart';
+
+void main() {
+  test('fromDate spans Saturday through the following Friday', () {
+    // 2026-03-05 is a Thursday.
+    final week = Week.fromDate(Date.raw(2026, 3, 5));
+
+    expect(week.startDate, equals(Date.raw(2026, 2, 28)));
+    expect(week.endDate, equals(Date.raw(2026, 3, 6)));
+    expect(week.daysInWeek, hasLength(7));
+    expect(week.daysInWeek.first, equals(week.startDate));
+    expect(week.daysInWeek.last, equals(week.endDate));
+  });
+
+  test('relative(0) matches now(), relative(1) is exactly one week later', () {
+    final thisWeek = Week.now();
+    final nextWeek = Week.relative(1);
+
+    expect(nextWeek.startDate, equals(thisWeek.startDate.addWeeks(1)));
+    expect(nextWeek.endDate, equals(thisWeek.endDate.addWeeks(1)));
+  });
+
+  test('equality is by start/end date, not identity', () {
+    final a = Week.fromDate(Date.raw(2026, 3, 5));
+    final b = Week.fromDate(Date.raw(2026, 3, 3));
+
+    expect(a, equals(b));
+  });
+}


### PR DESCRIPTION
Adds offline unit/request tests against fixtures, a local-only live-API coverage suite that exercises the real Untis API with real credentials to catch JSON parsing/schema drift, GitHub Actions CI (analyze/codegen/build/ offline-tests only, never the live tier), and wires both speeds into the Claude Code Stop hook.

Along the way, live testing against a real anonymous account (bs-gfv) surfaced and fixed a genuine auth bug: anonymous REST sessions need an anonymous-school-base64 header instead of a bearer JWT. It also confirmed that messages are permanently unavailable to anonymous accounts (403 Forbidden) and that some anonymous accounts have no timetable resource assigned server-side (null userData.elemType) — both are now asserted/ guarded for in the client and reflected in the live suite and UI (the messages entry is hidden from anonymous sessions) rather than treated as bugs to keep chasing. Also fixes an unrelated pre-existing bug in request_exams.dart (a stray double .result on the RPC response).