### PR TITLE
Bump to v2.0.1+2001, add release build script and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ Generate the nessessary code:
 ```shell
 dart run build_runner build
 ```
+
+### Release builds
+
+Release APKs (the ones published to GitHub Releases and mirrored by IzzyOnDroid) are built
+with [`tool/build_release_apk.sh`](tool/build_release_apk.sh).

--- a/fastlane/metadata/android/de/changelogs/2001.txt
+++ b/fastlane/metadata/android/de/changelogs/2001.txt
@@ -1,0 +1,8 @@
+Fehlerbehebungen:
+- Uhrzeiten wurden teilweise ohne führende Null angezeigt (z. B. 9:5 statt 09:05)
+- Das Klasse-Feld tauchte fälschlicherweise im Lehrer-Feld der Stundendetails auf
+- Der Kurzname des Raums wird jetzt einheitlich in der Stundenplankarte und den Stundendetails angezeigt
+- Die Statuskarte auf dem Startbildschirm berücksichtigt jetzt Kursfilter und Lücken im Stundenplan
+- Nachrichten zeigen jetzt Zeitstempel an, der Antwortverlauf ist chronologisch sortiert
+- Zu langer Text in Stundenplaneinträgen wird jetzt abgeschnitten statt überzulaufen
+- Nicht benötigte Speicher-/Medienberechtigungen wurden entfernt

--- a/fastlane/metadata/android/en-US/changelogs/2001.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2001.txt
@@ -1,0 +1,8 @@
+Bug fixes:
+- Fixed times sometimes showing without a leading zero (e.g. 9:5 instead of 09:05)
+- Fixed the Klasse field leaking into the Lehrer field in Stundendetails
+- Room short names are now shown consistently in the timetable card and Stundendetails
+- The home screen status card now respects course filters and lesson gaps
+- Message timestamps are now shown, and reply history is sorted chronologically
+- Long timetable entry text is now ellipsized instead of overflowing
+- Removed unused storage/media permissions the app never actually needed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: your_schedule
 description: Filter your Untis Schedule by classes you have chosen.
 
-version: 2.0.0+2000
+version: 2.0.1+2001
 
 environment:
   sdk: '>=3.11.0 <4.0.0'

--- a/tool/build_release_apk.sh
+++ b/tool/build_release_apk.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Builds the split-per-ABI release APKs the way they're actually published (GitHub
+# Releases / IzzyOnDroid).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ ! -f android/key.properties ]]; then
+  echo "warning: android/key.properties not found - the release build will be unsigned." >&2
+fi
+
+echo "==> flutter pub get"
+flutter pub get
+
+echo "==> stripping ELF build-id from the jni package's native build"
+: "${PUB_CACHE:=$HOME/.pub-cache}"
+shopt -s nullglob
+cmake_lists=("$PUB_CACHE"/hosted/*/jni-*/src/CMakeLists.txt)
+shopt -u nullglob
+if [[ ${#cmake_lists[@]} -eq 0 ]]; then
+  echo "error: no jni-*/src/CMakeLists.txt found under \$PUB_CACHE ($PUB_CACHE) - did 'flutter pub get' run?" >&2
+  exit 1
+fi
+sed -i -e 's/-Wl,/-Wl,--build-id=none,/' "${cmake_lists[@]}"
+
+echo "==> flutter build apk --release --split-per-abi"
+flutter build apk --release --split-per-abi
+
+echo "==> done"
+out_dir=build/app/outputs/flutter-apk
+for apk in "$out_dir"/app-*-release.apk; do
+  printf '%s  %s\n' "$(sha256sum "$apk" | cut -d' ' -f1)" "$apk"
+done


### PR DESCRIPTION
## Summary
- Version bump to `2.0.1+2001`.
- Add `tool/build_release_apk.sh` (documented in the README) to wrap the release build with the IzzyOnDroid-suggested `jni` build-id strip, addressing part of #23.
- Add fastlane changelog entries (`de`/`en-US`) for versionCode 2001 covering the bug fixes shipped since v2.0.0.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter build apk --release --split-per-abi` via the new script succeeds and produces signed APKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)